### PR TITLE
fix:add install maps directory in share to load map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ ament_auto_add_executable(vi_node
 install(TARGETS vi_node DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY maps DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
local環境でRVizにmapがでるようにした。
CMakeList.txtにmapsディレクトリをshare下に置くinstall文を追加した。